### PR TITLE
refactor(auth): eliminar parámetro innecesario en el componente de re…

### DIFF
--- a/components/auth/email-signup-view.tsx
+++ b/components/auth/email-signup-view.tsx
@@ -29,7 +29,7 @@ interface EmailSignupViewProps {
   onShowSocialSignup: () => void
 }
 
-export function EmailSignupView({ onShowSocialSignup: _ }: EmailSignupViewProps) {
+export function EmailSignupView() {
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)


### PR DESCRIPTION
…gistro por correo electrónico

- Se simplificó la firma de la función `EmailSignupView` al eliminar el parámetro `onShowSocialSignup`, manteniendo la funcionalidad existente sin cambios.